### PR TITLE
docs: Add frontmatter metadata to auth.mdx demo file

### DIFF
--- a/fern/markdown-content/auth.mdx
+++ b/fern/markdown-content/auth.mdx
@@ -1,1 +1,5 @@
+---
+title: Control Center
+---
+
 # This is a demo file that is authed


### PR DESCRIPTION
Added title frontmatter metadata "Control Center" to the auth demo markdown file. This change helps establish proper page metadata for the documentation system.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)