### PR TITLE
docs: Update subtitle text in home page

### DIFF
--- a/fern/markdown-content/home.mdx
+++ b/fern/markdown-content/home.mdx
@@ -1,7 +1,7 @@
 ---
 slug: home
 title: Welcome to Akamai TechDocs
-subtitle: Find guides, APIs, Terraform, code examples, and more for  products and services.
+subtitle: 'Find guides, APIs, Terraform, code examples, and more for  products and services. This is text. '
 hide-feedback: true
 layout: overview
 ---


### PR DESCRIPTION

Updates the subtitle text on the home page by adding "This is text." to the end of the existing subtitle. This appears to be a minor content update to the main documentation landing page.

The change maintains all other existing content and formatting, including the filter component at the bottom of the page.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)