### PR TITLE
docs: Update welcome page content with raw mode edit

### DIFF
--- a/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
+++ b/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
@@ -4,7 +4,7 @@ slug: welcome-to-edgeworkers
 description: Use Akamai's EdgeWorkers service to deploy JavaScript functions at the edge and create customized experiences for your website visitors.
 ---
 
-The quick brown fox jumped...
+The quick brown fox jumped... editing raw mode
 
 > It is what it is.
 


### PR DESCRIPTION

Updates the welcome page content in the EdgeWorkers documentation by modifying the introductory text to include a reference to raw mode editing. This is a minor content change that adds clarity around the editing mode context.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)