### PR TITLE
docs: Add heading and list items to welcome page

### DIFF
--- a/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
+++ b/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
@@ -6,6 +6,16 @@ description: Use Akamai's EdgeWorkers service to deploy JavaScript functions at 
 
 Adding new text here.
 
+## heading 2
+
+This is text.
+
+- list
+
+- list
+
+- list
+
 The quick brown fox jumped... editing raw mode
 
 > It is what it is.


### PR DESCRIPTION

Updates the EdgeWorkers welcome documentation by adding a new "heading 2" section with descriptive text and a bulleted list. This change enhances the document structure and improves content organization for better readability.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)