### PR TITLE
docs: Update welcome page text and login instructions

### DIFF
--- a/fern/edge-workers/guide/welcome-section/another-new-topic.mdx
+++ b/fern/edge-workers/guide/welcome-section/another-new-topic.mdx
@@ -4,3 +4,89 @@ slug: another-new-topic
 ---
 
 Test
+
+## HTML table
+
+## HTML table
+
+<table>
+<thead>
+<tr>
+<th style="text-align:left">What is it?</th>
+<th style="text-align:center">Quantity</th>
+<th style="text-align:left">Example</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+**List example**
+
+</td>
+<td style="text-align:center">
+
+37
+
+</td>
+<td>
+
+Here are the options you'll see when you click the **Additional features** button:
+
+- **I want emojis**. Enable this to support [emojis](https://en.wikipedia.org/wiki/Emoji).
+
+- **Enable YouTube**. Click this to enable support for [YouTube](#https://www.youtube.com).
+
+- **Add Images**. Enable this to add [images](doc:c-images) to your document.
+
+- Do variables work?  ​Akamai Control Center​
+
+</td>
+</tr>
+<tr>
+<td>
+
+**Code snippet**
+
+</td>
+<td style="text-align:center">
+
+12
+
+</td>
+<td>
+
+```
+{
+    "name": "http2",
+    "options": {
+       "enabled": ""
+    }
+},
+```
+</td>
+  
+</tr>
+<tr>
+  
+<td>
+
+This is a test
+
+</td>
+<td>
+
+This is a test
+
+</td>
+<td>
+
+> 📘 Adding a callout
+> 
+> You can also insert a callout into an HTML table cell by typing `/callout` .
+
+</td>
+  
+</tr>
+</tbody>
+</table>

--- a/fern/edge-workers/guide/welcome-section/another-new-topic.mdx
+++ b/fern/edge-workers/guide/welcome-section/another-new-topic.mdx
@@ -1,0 +1,6 @@
+---
+title: Another new topic
+slug: another-new-topic
+---
+
+Test

--- a/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
+++ b/fern/markdown-content/v1/Welcome/welcome-to-edgeworkers.md
@@ -4,7 +4,7 @@ slug: welcome-to-edgeworkers
 description: Use Akamai's EdgeWorkers service to deploy JavaScript functions at the edge and create customized experiences for your website visitors.
 ---
 
-Adding new text here.
+Adding new text here. Test
 
 ## heading 2
 
@@ -20,8 +20,7 @@ The quick brown fox jumped... editing raw mode
 
 > It is what it is.
 
-
-1. Log in to <Markdown src="PORTAL_NICKNAME.mdx" />.
+1. Log in to Control Center .
 
 2. Step 2
 


### PR DESCRIPTION

Updates the welcome page content with minor text changes and simplifies the login instruction by replacing the portal nickname markdown component with "Control Center". These changes improve readability and maintain consistency in the documentation.     
<br>
    
🌿 _This PR title and description were generated by Fern._
    [(buildwithfern.com)](https://www.buildwithfern.com)